### PR TITLE
Remove usage of deprecated function int_from_bytes

### DIFF
--- a/test/device/test_ec.py
+++ b/test/device/test_ec.py
@@ -177,7 +177,7 @@ class TestSecpEcdsa(YubiHsmTestCase):
 
         digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
         digest.update(data)
-        h = int.int_from_bytes(digest.finalize(), "big")
+        h = int.from_bytes(digest.finalize(), "big")
 
         # The assumption here is that for 1024 runs we should get a distribution
         # where each single bit is set between 400 and 1024 - 400 times.

--- a/test/device/test_ec.py
+++ b/test/device/test_ec.py
@@ -26,7 +26,6 @@ from yubihsm.exceptions import YubiHsmDeviceError
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, ed25519, utils as crypto_utils
-from cryptography.utils import int_from_bytes
 from binascii import a2b_hex
 import os
 import struct
@@ -178,7 +177,7 @@ class TestSecpEcdsa(YubiHsmTestCase):
 
         digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
         digest.update(data)
-        h = int_from_bytes(digest.finalize(), "big")
+        h = int.int_from_bytes(digest.finalize(), "big")
 
         # The assumption here is that for 1024 runs we should get a distribution
         # where each single bit is set between 400 and 1024 - 400 times.

--- a/test/device/test_rsa.py
+++ b/test/device/test_rsa.py
@@ -22,7 +22,7 @@ from yubihsm.exceptions import YubiHsmDeviceError
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
-from cryptography.utils import int_from_bytes, int_to_bytes
+from cryptography.utils import int_to_bytes
 from binascii import a2b_hex
 import os
 
@@ -115,7 +115,7 @@ class TestRsaPkcs1v1_5(YubiHsmTestCase):
         for m in rawmessages:
             error = ERROR.OK
             m = m.ljust(256, b"\xc3")
-            m_int = int_from_bytes(m, "big")
+            m_int = int.int_from_bytes(m, "big")
             enc = pow(m_int, numbers.e, numbers.n)
             try:
                 key.decrypt_pkcs1v1_5(int_to_bytes(enc).rjust(256, b"\x00"))

--- a/test/device/test_rsa.py
+++ b/test/device/test_rsa.py
@@ -115,7 +115,7 @@ class TestRsaPkcs1v1_5(YubiHsmTestCase):
         for m in rawmessages:
             error = ERROR.OK
             m = m.ljust(256, b"\xc3")
-            m_int = int.int_from_bytes(m, "big")
+            m_int = int.from_bytes(m, "big")
             enc = pow(m_int, numbers.e, numbers.n)
             try:
                 key.decrypt_pkcs1v1_5(int_to_bytes(enc).rjust(256, b"\x00"))

--- a/test/device/test_wrap.py
+++ b/test/device/test_wrap.py
@@ -142,7 +142,7 @@ class TestWrap(YubiHsmTestCase):
         # dec = decryptor.update(data)
 
         # numbers = eckey.private_numbers()
-        # serialized = int_from_bytes(numbers.private_value, 'big')
+        # serialized = int.int_from_bytes(numbers.private_value, 'big')
         # self.assertEqual(serialized, dec[-len(serialized):])
 
         asymkey.delete()

--- a/test/device/test_wrap.py
+++ b/test/device/test_wrap.py
@@ -142,7 +142,7 @@ class TestWrap(YubiHsmTestCase):
         # dec = decryptor.update(data)
 
         # numbers = eckey.private_numbers()
-        # serialized = int.int_from_bytes(numbers.private_value, 'big')
+        # serialized = int.from_bytes(numbers.private_value, 'big')
         # self.assertEqual(serialized, dec[-len(serialized):])
 
         asymkey.delete()

--- a/yubihsm/objects.py
+++ b/yubihsm/objects.py
@@ -32,7 +32,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-from cryptography.utils import int_to_bytes, int_from_bytes
+from cryptography.utils import int_to_bytes
 from collections import namedtuple
 import six
 import copy
@@ -520,7 +520,7 @@ class AsymmetricKey(YhsmObject):
         algo = ALGORITHM(six.indexbytes(ret, 0))
         raw_key = ret[1:]
         if algo in [ALGORITHM.RSA_2048, ALGORITHM.RSA_3072, ALGORITHM.RSA_4096]:
-            num = int_from_bytes(raw_key, "big")
+            num = int.int_from_bytes(raw_key, "big")
             pubkey = rsa.RSAPublicNumbers(e=0x10001, n=num)
         elif algo in [
             ALGORITHM.EC_P224,
@@ -533,8 +533,8 @@ class AsymmetricKey(YhsmObject):
             ALGORITHM.EC_BP512,
         ]:
             c_len = len(raw_key) // 2
-            x = int_from_bytes(raw_key[:c_len], "big")
-            y = int_from_bytes(raw_key[c_len:], "big")
+            x = int.int_from_bytes(raw_key[:c_len], "big")
+            y = int.int_from_bytes(raw_key[c_len:], "big")
             pubkey = ec.EllipticCurvePublicNumbers(curve=algo.to_curve(), x=x, y=y)
         elif algo in [ALGORITHM.EC_ED25519]:
             return _deserialize_ed25519_public_key(raw_key)

--- a/yubihsm/objects.py
+++ b/yubihsm/objects.py
@@ -520,7 +520,7 @@ class AsymmetricKey(YhsmObject):
         algo = ALGORITHM(six.indexbytes(ret, 0))
         raw_key = ret[1:]
         if algo in [ALGORITHM.RSA_2048, ALGORITHM.RSA_3072, ALGORITHM.RSA_4096]:
-            num = int.int_from_bytes(raw_key, "big")
+            num = int.from_bytes(raw_key, "big")
             pubkey = rsa.RSAPublicNumbers(e=0x10001, n=num)
         elif algo in [
             ALGORITHM.EC_P224,
@@ -533,8 +533,8 @@ class AsymmetricKey(YhsmObject):
             ALGORITHM.EC_BP512,
         ]:
             c_len = len(raw_key) // 2
-            x = int.int_from_bytes(raw_key[:c_len], "big")
-            y = int.int_from_bytes(raw_key[c_len:], "big")
+            x = int.from_bytes(raw_key[:c_len], "big")
+            y = int.from_bytes(raw_key[c_len:], "big")
             pubkey = ec.EllipticCurvePublicNumbers(curve=algo.to_curve(), x=x, y=y)
         elif algo in [ALGORITHM.EC_ED25519]:
             return _deserialize_ed25519_public_key(raw_key)


### PR DESCRIPTION
This PR removes usages of the deprecated method `utils.int_from_bytes`. This method was deprecated in Python's cryptography library in version 3.4 as seen here: https://github.com/pyca/cryptography/blob/main/src/cryptography/utils.py#L162