### PR TITLE
Avoid timeouts with usb backend

### DIFF
--- a/yubihsm/backends/usb.py
+++ b/yubihsm/backends/usb.py
@@ -40,9 +40,15 @@ class UsbBackend(YhsmBackend):
             raise YubiHsmConnectionError("No YubiHSM found.")
 
         try:
-            device.set_configuration()
-        except usb.core.USBError as e:
-            raise YubiHsmConnectionError(e)
+            cfg = device.get_active_configuration()
+        except usb.core.USBError:
+            cfg = None
+
+        if cfg is None or cfg.bConfigurationValue != 0x01:
+            try:
+                device.set_configuration(0x01)
+            except usb.core.USBError as e:
+                raise YubiHsmConnectionError(e)
 
         # Flush any data waiting to be read
         try:


### PR DESCRIPTION
This fixes an issue for us when running tests using pyusb backend, rather than the http connector.

To reproduce, on a Linux host you can try the following:
```
c = YubiHsm.connect("yhusb://")
... do stuff
c.close()
c = YubiHsm.connect("yhusb://")
... try to do stuff - bulk_read times out after 300s
```
Calling set_configuration() unconditionally causes read/write timeouts when the device has already been configured.

FWIW yubikey-personalization does something similar, though the comment alludes that it's required for virtualization, which is not the case here (we see the issue on a Linux host without virtualization):

https://github.com/Yubico/yubikey-personalization/blob/master/ykcore/ykcore_libusb-1.0.c#L209

Also:

https://github.com/pyusb/pyusb/blob/master/docs/faq.rst#how-not-to-call-set_configuration-on-a-device-already-configured-with-the-selected-configuration

https://libusb.sourceforge.io/api-1.0/libusb_caveats.html#configsel