### PR TITLE
tests: fix test_hmac_vectors

### DIFF
--- a/tests/device/test_hmac.py
+++ b/tests/device/test_hmac.py
@@ -96,10 +96,7 @@ def test_generate_hmac(session, algorithm, expect_len):
     ],
 )
 def test_hmac_vectors(session, vector):
-    key1_id = random.randint(1, 0xFFFE)
-    key2_id = random.randint(1, 0xFFFE)
-    key3_id = random.randint(1, 0xFFFE)
-    key4_id = random.randint(1, 0xFFFE)
+    key1_id, key2_id, key3_id, key4_id = random.sample(range(1, 0xFFFE), 4)
 
     caps = CAPABILITY.SIGN_HMAC | CAPABILITY.VERIFY_HMAC
 


### PR DESCRIPTION
- Some test runs generate a duplicate random key_id, which cause the test to fail as we cannout PUT a key with the same key_id.

- Modify the key_id generation to generate four unique random key_ids, with no possibility of duplicates.