### PR TITLE
Add support for AES encryption/decryption in ECB & CBC mode

### DIFF
--- a/tests/device/test_aes.py
+++ b/tests/device/test_aes.py
@@ -1,0 +1,115 @@
+# Copyright 2016-2018 Yubico AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from yubihsm.defs import ALGORITHM, CAPABILITY
+from yubihsm.objects import SymmetricKey
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from typing import Optional
+import os
+import pytest
+
+AES_ALGORITHMS = (ALGORITHM.AES128, ALGORITHM.AES192, ALGORITHM.AES256)
+AES_CAPABILITIES = (
+    CAPABILITY.ENCRYPT_ECB
+    | CAPABILITY.DECRYPT_ECB
+    | CAPABILITY.ENCRYPT_CBC
+    | CAPABILITY.DECRYPT_CBC
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def prerequisites(info):
+    if info.version < (2, 3, 0):
+        pytest.skip("Symmetric keys require YubiHSM 2.3.0")
+
+
+@pytest.fixture(scope="module", params=AES_ALGORITHMS)
+def generated_key(session, request):
+    algorithm = request.param
+    key = SymmetricKey.generate(
+        session,
+        0,
+        "Generated AES Key %x" % algorithm,
+        0xFFFF,
+        AES_CAPABILITIES,
+        algorithm,
+    )
+    yield key
+    key.delete()
+
+
+@pytest.fixture(scope="module", params=AES_ALGORITHMS)
+def imported_key(session, request):
+    algorithm = request.param
+    key_to_import = os.urandom(algorithm.to_key_size())
+
+    key = SymmetricKey.put(
+        session,
+        0,
+        "Imported AES Key %x" % algorithm,
+        0xFFFF,
+        AES_CAPABILITIES,
+        algorithm,
+        key_to_import,
+    )
+    yield key, key_to_import
+    key.delete()
+
+
+def test_import_unsupported_key(session):
+    # Key length must match algorithm
+    with pytest.raises(ValueError):
+        SymmetricKey.put(
+            session,
+            0,
+            "Test PUT unsupported key",
+            0xFFFF,
+            AES_CAPABILITIES,
+            ALGORITHM.AES128,
+            os.urandom(24),
+        )
+
+
+class TestSymmetricECB:
+    def validate_ecb(self, keyobj: SymmetricKey, key: Optional[bytes] = None):
+        pt = os.urandom(256)
+        ct = keyobj.encrypt_ecb(pt)
+        if key:
+            encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
+            assert ct == encryptor.update(pt) + encryptor.finalize()
+        assert pt == keyobj.decrypt_ecb(ct)
+
+    def test_ecb_generated_key(self, generated_key):
+        self.validate_ecb(generated_key)
+
+    def test_ecb_imported_key(self, imported_key):
+        self.validate_ecb(*imported_key)
+
+
+class TestSymmetricCBC:
+    def validate_cbc(self, keyobj: SymmetricKey, key: Optional[bytes] = None):
+        pt = os.urandom(256)
+        iv = os.urandom(16)
+        ct = keyobj.encrypt_cbc(iv, pt)
+        if key:
+            encryptor = Cipher(algorithms.AES(key), modes.CBC(iv)).encryptor()
+            assert ct == encryptor.update(pt) + encryptor.finalize()
+        assert pt == keyobj.decrypt_cbc(iv, ct)
+
+    def test_cbc_generated_key(self, generated_key):
+        self.validate_cbc(generated_key)
+
+    def test_cbc_imported_key(self, imported_key):
+        self.validate_cbc(*imported_key)

--- a/tests/device/test_delete.py
+++ b/tests/device/test_delete.py
@@ -20,6 +20,7 @@ from yubihsm.objects import (
     AsymmetricKey,
     OtpAeadKey,
     WrapKey,
+    SymmetricKey,
 )
 from yubihsm.exceptions import YubiHsmDeviceError
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -122,3 +123,19 @@ def test_otp_aead_key(hsm, session):
         os.urandom(32),
     )
     _test_delete(hsm, session, obj, CAPABILITY.DELETE_OTP_AEAD_KEY)
+
+
+def test_symmetric_key(hsm, session, info):
+    if info.version < (2, 3, 0):
+        pytest.skip("Symmetric keys require YubiHSM 2.3.0")
+
+    obj = SymmetricKey.put(
+        session,
+        0,
+        "Test delete symmetric",
+        0xFFFF,
+        CAPABILITY.DECRYPT_ECB,
+        ALGORITHM.AES128,
+        os.urandom(16),
+    )
+    _test_delete(hsm, session, obj, CAPABILITY.DELETE_SYMMETRIC_KEY)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -316,7 +316,7 @@ class TestAuthsession(unittest.TestCase):
         # from send_secure_cmd
         session.send_secure_cmd.assert_called_with(
             72,
-            b"\x01\x00\x02\x02\x01\x03\xff\xff\x04\x00?\xff\xff\xff\xff\xff\xff\x05\x15",  # noqa E501
+            b"\x01\x00\x02\x02\x01\x03\xff\xff\x04\x00\x3f\xff\xff\xff\xff\xff\xff\x05\x15",  # noqa E501
         )
 
     def test_list_objects2(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -316,7 +316,7 @@ class TestAuthsession(unittest.TestCase):
         # from send_secure_cmd
         session.send_secure_cmd.assert_called_with(
             72,
-            b"\x01\x00\x02\x02\x01\x03\xff\xff\x04\x00\x00\x7f\xff\xff\xff\xff\xff\x05\x15",  # noqa E501
+            b"\x01\x00\x02\x02\x01\x03\xff\xff\x04\x00?\xff\xff\xff\xff\xff\xff\x05\x15",  # noqa E501
         )
 
     def test_list_objects2(self):

--- a/yubihsm/defs.py
+++ b/yubihsm/defs.py
@@ -99,6 +99,12 @@ class COMMAND(IntEnum):
     SIGN_EDDSA = 0x6A
     BLINK_DEVICE = 0x6B
     CHANGE_AUTHENTICATION_KEY = 0x6C
+    PUT_SYMMETRIC_KEY = 0x6D
+    GENERATE_SYMMETRIC_KEY = 0x6E
+    DECRYPT_ECB = 0x6F
+    ENCRYPT_ECB = 0x70
+    DECRYPT_CBC = 0x71
+    ENCRYPT_CBC = 0x72
 
     ERROR = 0x7F
 
@@ -161,6 +167,12 @@ class ALGORITHM(IntEnum):
     RSA_PKCS1_DECRYPT = 48
     EC_P256_YUBICO_AUTHENTICATION = 49
 
+    AES128 = 50
+    AES192 = 51
+    AES256 = 52
+    AES_ECB = 53
+    AES_CBC = 54
+
     def to_curve(self) -> ec.EllipticCurve:
         """Return a Cryptography EC curve instance for a given member.
 
@@ -191,6 +203,19 @@ class ALGORITHM(IntEnum):
                 return key
         raise ValueError("Unsupported curve type: %s" % curve.name)
 
+    def to_key_size(self) -> int:
+        """Return the expected size (in bytes) of a key corresponding to an algorithm.
+
+        :return: The corresponding key size (in bytes) to an algorithm.
+
+        :Example:
+
+        >>> ALGORITHM.AES128.to_key_size()
+        16
+        """
+
+        return _key_size_table[self]
+
 
 _curve_table = {
     ALGORITHM.EC_P224: ec.SECP224R1,
@@ -202,6 +227,8 @@ _curve_table = {
     ALGORITHM.EC_BP384: ec.BrainpoolP384R1,
     ALGORITHM.EC_BP512: ec.BrainpoolP512R1,
 }
+
+_key_size_table = {ALGORITHM.AES128: 16, ALGORITHM.AES192: 24, ALGORITHM.AES256: 32}
 
 
 @unique
@@ -227,6 +254,7 @@ class OBJECT(IntEnum):
     HMAC_KEY = 0x05
     TEMPLATE = 0x06
     OTP_AEAD_KEY = 0x07
+    SYMMETRIC_KEY = 0x08
 
 
 @unique
@@ -308,6 +336,13 @@ class CAPABILITY(IntFlag):
     DELETE_TEMPLATE = 1 << 0x2C
     DELETE_OTP_AEAD_KEY = 1 << 0x2D
     CHANGE_AUTHENTICATION_KEY = 1 << 0x2E
+    PUT_SYMMETRIC_KEY = 1 << 0x2F
+    GENERATE_SYMMETRIC_KEY = 1 << 0x30
+    DELETE_SYMMETRIC_KEY = 1 << 0x31
+    DECRYPT_ECB = 1 << 0x32
+    ENCRYPT_ECB = 1 << 0x33
+    DECRYPT_CBC = 1 << 0x34
+    ENCRYPT_CBC = 1 << 0x35
 
     @_enum_prop
     def NONE(cls) -> "CAPABILITY":


### PR DESCRIPTION
This adds support for `SymmetricKey` objects, used to encrypt/decrypt AES in ECB & CBC mode. 