### PR TITLE
Add check for public exponent and key size during RSA key import

### DIFF
--- a/tests/device/test_rsa.py
+++ b/tests/device/test_rsa.py
@@ -355,3 +355,35 @@ def test_rsa_oaep_vectors(session, vector):
     assert vector["msg"] == dec
 
     asymkey.delete()
+
+
+def test_import_invalid_public_exponent(session):
+    key = rsa.generate_private_key(
+        public_exponent=3, key_size=2048, backend=default_backend()
+    )
+
+    with pytest.raises(ValueError):
+        AsymmetricKey.put(
+            session,
+            0,
+            "Test PUT invalid exponent",
+            0xFFFF,
+            CAPABILITY.SIGN_PKCS,
+            key,
+        )
+
+
+def test_import_invalid_key_size(session):
+    key = rsa.generate_private_key(
+        public_exponent=0x10001, key_size=512, backend=default_backend()
+    )
+
+    with pytest.raises(ValueError):
+        AsymmetricKey.put(
+            session,
+            0,
+            "Test PUT invalid key size",
+            0xFFFF,
+            CAPABILITY.SIGN_PKCS,
+            key,
+        )

--- a/yubihsm/objects.py
+++ b/yubihsm/objects.py
@@ -526,13 +526,11 @@ class AsymmetricKey(YhsmObject):
         :return: A reference to the newly created object.
         """
         if isinstance(key, rsa.RSAPrivateKeyWithSerialization):
-            public_key = key.public_key()
-            public_numbers = public_key.public_numbers()
-            if public_numbers.e != RSA_PUBLIC_EXPONENT:
+            rsa_numbers = key.private_numbers()
+            if rsa_numbers.public_numbers.e != RSA_PUBLIC_EXPONENT:
                 raise ValueError("Unsupported public exponent")
             if key.key_size not in RSA_SIZES:
                 raise ValueError("Unsupported key size")
-            rsa_numbers = key.private_numbers()
             serialized = int.to_bytes(
                 rsa_numbers.p, key.key_size // 8 // 2, "big"
             ) + int.to_bytes(rsa_numbers.q, key.key_size // 8 // 2, "big")

--- a/yubihsm/objects.py
+++ b/yubihsm/objects.py
@@ -37,8 +37,16 @@ import struct
 
 
 LABEL_LENGTH = 40
+
 MAX_AES_PAYLOAD_SIZE = 2026
 AES_BLOCK_SIZE = 16
+
+RSA_PUBLIC_EXPONENT = 65537
+RSA_SIZES = [
+    2048,
+    3072,
+    4096,
+]
 
 
 def _label_pack(label: Union[str, bytes]) -> bytes:
@@ -518,6 +526,12 @@ class AsymmetricKey(YhsmObject):
         :return: A reference to the newly created object.
         """
         if isinstance(key, rsa.RSAPrivateKeyWithSerialization):
+            public_key = key.public_key()
+            public_numbers = public_key.public_numbers()
+            if public_numbers.e != RSA_PUBLIC_EXPONENT:
+                raise ValueError("Unsupported public exponent")
+            if key.key_size not in RSA_SIZES:
+                raise ValueError("Unsupported key size")
             rsa_numbers = key.private_numbers()
             serialized = int.to_bytes(
                 rsa_numbers.p, key.key_size // 8 // 2, "big"


### PR DESCRIPTION
This change checks that the public exponent (e) and key size is supported when importing an RSA key into the YubiHSM. 