### PR TITLE
Don't install docs at top level of wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
 	"Topic :: Software Development :: Libraries"
 ]
 include = [
-  "COPYING",
-  "NEWS",
-  "README.adoc",
+  { path = "COPYING", format = "sdist" },
+  { path = "NEWS", format = "sdist" },
+  { path = "README.adoc", format = "sdist" },
   "tests/",
 ]
 


### PR DESCRIPTION
Telling Poetry to install the `COPYING`, `NEWS`, and `README.adoc` files without qualification causes it to install those files at the very top level of the wheel, outside the `yubihsm/` directory, and thus to potentially clash with other packages.

We only need to explicitly install them in the sdist.  The wheel still ends up with copies of those files in `yubihsm-*.dist-info/`, so no information is lost.