### PR TITLE
Delete test objects when done with them

### DIFF
--- a/tests/device/test_delete.py
+++ b/tests/device/test_delete.py
@@ -107,7 +107,9 @@ def test_wrap_key(hsm, session):
 
 
 def test_hmac_key(hsm, session):
-    obj = HmacKey.put(session, 0, "Test delete HMAC", 1, CAPABILITY.SIGN_HMAC, b"key")
+    obj = HmacKey.put(
+        session, 0, "Test delete HMAC", 1, CAPABILITY.SIGN_HMAC, bytes(16)
+    )
     _test_delete(hsm, session, obj, CAPABILITY.DELETE_HMAC_KEY)
 
 

--- a/tests/device/test_hmac.py
+++ b/tests/device/test_hmac.py
@@ -48,6 +48,8 @@ def test_generate_hmac(session, algorithm, expect_len):
     assert resp != resp2
     assert hmackey.verify_hmac(resp2, data)
 
+    hmackey.delete()
+
     hmackey = HmacKey.generate(session, 0, "Generate HMAC", 1, caps, algorithm)
 
     resp = hmackey.sign_hmac(data)
@@ -198,6 +200,7 @@ def test_import_large_keys(session, vector):
 
     assert key.sign_hmac(vector["chal"]) == vector["exp_sha"]
     assert key.verify_hmac(vector["exp_sha"], vector["chal"])
+    key.delete()
 
 
 def test_import_invalid_algorithm(session):

--- a/tests/device/test_logs.py
+++ b/tests/device/test_logs.py
@@ -92,6 +92,8 @@ def test_full_log(session):
         last_digest = digest.finalize()[:16]
         assert last_digest == logs[i].digest
 
+    hmackey.delete()
+
 
 def test_wrong_chain(session):
     hmackey = HmacKey.generate(
@@ -117,6 +119,8 @@ def test_wrong_chain(session):
     wrong_line = replace(last_line, digest=os.urandom(16))
     with pytest.raises(YubiHsmInvalidResponseError):
         session.get_log_entries(wrong_line)
+
+    hmackey.delete()
 
 
 def test_forced_log(hsm, session):
@@ -159,6 +163,8 @@ def test_forced_log(hsm, session):
         resp = hmackey.sign_hmac(data)
         assert len(resp) == 32
         assert hmackey.verify_hmac(resp, data)
+
+    hmackey.delete()
 
 
 def test_logs_after_reset(hsm, connect_hsm, session, info):


### PR DESCRIPTION
While here, import a slightly larger HMAC key in the deletion test.